### PR TITLE
Fix for missed semaphore release on Milight._off()

### DIFF
--- a/lib/milight.js
+++ b/lib/milight.js
@@ -197,5 +197,7 @@ Milight.prototype._off = function(zoneId, callback) {
 		}
 
 		self._currentZone = undefined;
+
+    callback();
 	});
 };


### PR DESCRIPTION
Causes all operations after a call to ._off() to wait indefinitely. You can observe the issue with the following script:

``` javascript
var M = require('./lib/milight');
m = new M();

m.off();
m.on();

setTimeout(function() {
  var queueLength = m._socketSem.queue.length;

  if (queueLength > 0) {
    console.error('Well that should\'t be happening:', queueLength);

    process.exit();
  }
}, 1000);
```
